### PR TITLE
Only add -Werror=declaration-after-statement for 5.035004 and earlier

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,9 @@ my $DEFINE = '';
 # https://gcc.gnu.org/onlinedocs/gcc-4.0.0/gcc/Warning-Options.html
 if ($Config{gccversion} and $Config{gccversion} =~ /^(\d+\.\d+)\./) {
   my $gccver = $1;
-  if ($gccver >= 4.3) {
+  if ($] > 5.035004) {
+    $DEFINE = '-Wall -Wextra -W';
+  } elsif ($gccver >= 4.3) {
     $DEFINE = '-Wall -Werror=declaration-after-statement -Wextra -W';
   } elsif ($gccver >= 3.4) {
     $DEFINE = '-Wall -Wdeclaration-after-statement -Wextra -W';


### PR DESCRIPTION
Perl v5.35.5 now uses some C99 features. This means that Perl's headers now contain some code with mixed declarations and code., and so won't compile with -Werror=declaration-after-statement

It still makes sense to add this flag for builds for earlier perl versions, because they support long obsolete compilers that are strict in rejecting certain C99 features, so adding this gcc flag allows us to audit that our code does not violate this.